### PR TITLE
Fix lint warnings

### DIFF
--- a/core/gpt_semantics/gpt_marker_parser.py
+++ b/core/gpt_semantics/gpt_marker_parser.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Dict, Optional
+from typing import Optional
 
 try:
     import openai

--- a/core/marker_model/__init__.py
+++ b/core/marker_model/__init__.py
@@ -1,1 +1,5 @@
+"""Utilities for working with the codebook package."""
+
 from .codebook_manager import check_consistency
+
+__all__ = ["check_consistency"]


### PR DESCRIPTION
## Summary
- address unused imports found by ruff
- expose `check_consistency` in `core.marker_model`

## Testing
- `python -m compileall -q`
- `python -m core.marker_model.validate_codebook`
- `ruff check .`
- `streamlit run frontend/streamlit_gui/streamlit_app.py` *(fails to open browser in headless mode)*
- `python installer/install_gui.py` *(fails: no display)*


------
https://chatgpt.com/codex/tasks/task_b_686b5896c84883228fc2b3d579517170