### PR TITLE
Add user experience notes and new test

### DIFF
--- a/USER_TEST_NOTES.md
+++ b/USER_TEST_NOTES.md
@@ -1,0 +1,37 @@
+# User Experience Test Notes
+
+This document summarizes the end-to-end test of the **LIFe_LM** prototype.
+
+## Installation
+1. Ensure Python 3.11+ is available.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. (Optional) provide an `OPENAI_API_KEY` as environment variable for GPT and Whisper API usage.
+
+## Configuration Options
+- `OPENAI_API_KEY` – required for online transcription and GPT marker parsing.
+- Local transcription via `faster-whisper` can be enabled in the Streamlit UI using the checkbox `Lokale Transkription nutzen`.
+
+## Validation
+The codebook YAML files can be checked with:
+```bash
+python -m core.marker_model.validate_codebook
+```
+Example output shows missing references and helps keep the dataset consistent.
+
+## Creating YAML Entries
+The `core.marker_model.codebook_manager` module provides helper functions:
+- `add_marker`, `add_indikator`, `add_meta`
+- `update_marker`, `update_indikator`, `update_meta`
+- `check_consistency`
+
+Using these helpers new markers and indicators are persisted to the YAML files.
+
+## Test Summary
+`pytest` runs two unit tests:
+1. `tests/test_openai_api.py` – verifies the OpenAI client API.
+2. `tests/test_codebook_manager.py` – exercises adding markers and indicators in a temporary workspace and checks consistency.
+
+Both tests pass after installation.

--- a/tests/test_codebook_manager.py
+++ b/tests/test_codebook_manager.py
@@ -1,0 +1,46 @@
+import tempfile
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import shutil
+from pathlib import Path
+import yaml
+import unittest
+
+from core.marker_model import codebook_manager as cm
+
+
+class TestCodebookManager(unittest.TestCase):
+    def setUp(self):
+        self.orig_paths = (cm.MARKER_FILE, cm.INDIKATOREN_FILE, cm.META_FILE)
+        self.tmpdir = tempfile.mkdtemp()
+        cm.MARKER_FILE = Path(self.tmpdir) / 'marker_library.yaml'
+        cm.INDIKATOREN_FILE = Path(self.tmpdir) / 'indikatoren.yaml'
+        cm.META_FILE = Path(self.tmpdir) / 'meta_indikatoren.yaml'
+        with open(cm.MARKER_FILE, 'w') as f:
+            yaml.dump({'marker_library': []}, f)
+        with open(cm.INDIKATOREN_FILE, 'w') as f:
+            yaml.dump({'indikatoren': []}, f)
+        with open(cm.META_FILE, 'w') as f:
+            yaml.dump({'meta_indikatoren': []}, f)
+
+    def tearDown(self):
+        cm.MARKER_FILE, cm.INDIKATOREN_FILE, cm.META_FILE = self.orig_paths
+        shutil.rmtree(self.tmpdir)
+
+    def test_add_marker_and_indikator(self):
+        cm.add_marker({
+            'id': 'm1',
+            'typ': 'test',
+            'hinweis': 'h',
+            'beispiel_aussage': 'b',
+            'linked_indicators': ['i1']
+        })
+        cm.add_indikator({
+            'id': 'i1',
+            'name': 'I1',
+            'meta_indikatoren': [],
+            'marker_ids': ['m1']
+        })
+        errors = cm.check_consistency()
+        self.assertEqual(errors, {'indikatoren': [], 'meta': [], 'marker': []})
+


### PR DESCRIPTION
## Summary
- document setup and configuration in `USER_TEST_NOTES.md`
- add `test_codebook_manager.py` verifying YAML persistence via `codebook_manager`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d6465c8e88322982e7f64071e9f85